### PR TITLE
Fixed assert failed on OS X 10.9 by enlarging the memory size. 

### DIFF
--- a/run_analyzer
+++ b/run_analyzer
@@ -3,6 +3,6 @@
 if [[ "$1" != "" && "$2" != "" ]]; then
         java -Xmx1024m -cp lib/*:esalib.jar clldsystem.esa.ESAAnalyzer "$1" "$2"
 else
-        java -cp lib/*:esalib.jar clldsystem.esa.ESAAnalyzer
+        java -Xmx1024m -cp lib/*:esalib.jar clldsystem.esa.ESAAnalyzer
 fi
 

--- a/run_analyzer
+++ b/run_analyzer
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 if [[ "$1" != "" && "$2" != "" ]]; then
-        java -cp lib/*:esalib.jar clldsystem.esa.ESAAnalyzer "$1" "$2"
+        java -Xmx1024m -cp lib/*:esalib.jar clldsystem.esa.ESAAnalyzer "$1" "$2"
 else
         java -cp lib/*:esalib.jar clldsystem.esa.ESAAnalyzer
 fi


### PR DESCRIPTION
It seems this error can occur even all of the permission are set to 777. So I debugged it, the program would halt inside the initDB() method call and I assumed loading everything into the memory was a huge cost, after specified the memory size, the assert fail disappeared.
